### PR TITLE
Fix the missing window icon when running under Wayland

### DIFF
--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -50,7 +50,10 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
     QApplication::setWindowIcon(QIcon(":/images/icon.png"));
+
+#ifdef Q_OS_LINUX
     a.setDesktopFileName("xapkd");
+#endif
 
     XOptions xOptions;
 

--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
     QApplication::setWindowIcon(QIcon(":/images/icon.png"));
+    a.setDesktopFileName("xapkd");
 
     XOptions xOptions;
 


### PR DESCRIPTION
Currently, when running under Wayland, the window icon will fallback to the default Wayland icon.
Setting the desktop filename can solve this problem.